### PR TITLE
fix: development with Docker

### DIFF
--- a/Docker_README.md
+++ b/Docker_README.md
@@ -1,3 +1,21 @@
+# Clone SplashKit Repositories
+1. Clone the SplashKit-Core Repository
+    git clone https://github.com/thoth-tech/splashkit-core.git
+
+2. Clone the SplashKit-Translator Repository
+    git clone https://github.com/thoth-tech/splashkit-translator.git
+
+# Install Docker
+https://docs.docker.com/engine/install/
+
+## Ubuntu
+```sh
+sudo apt-get update
+```
+```sh 
+sudo apt-get install docker-ce docker-ce-cli containerd.io
+```
+
 # To Build
 
 Run the following command in the `splashkit-translator` root directory

--- a/Docker_README.md
+++ b/Docker_README.md
@@ -1,6 +1,13 @@
 # To Build
-Run the following command in the translator directory
-` docker build --tag headerdoc -f Dockerfile .`
+
+Run the following command in the `splashkit-translator` root directory
+
+```sh
+docker build --tag headerdoc -f Dockerfile .
+```
 
 # To Run
-`docker run --rm -v <absolute path to splashkit-core>:/splashkit/ headerdoc ./translate -i /splashkit/ -o /splashkit/generated -g cpp,docs,clib,python,pascal,csharp`
+
+```sh
+docker run --rm -v <absolute path to splashkit-core>:/splashkit/ headerdoc ./translate -i /splashkit/ -o /splashkit/generated -g cpp,docs,clib,python,pascal,csharp
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ USER 0
 RUN yum update -y \
     && yum install -y \
     libxml2-devel \
-    libxml2-devel \
     perl-Devel-Peek \
     perl-FreezeThaw \
     perl-HTML-Parser \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,19 @@
-FROM centos:centos8
+FROM centos/ruby-27-centos7:2.7
+
+USER 0
+
+RUN yum update -y \
+    && yum install -y \
+    libxml2-devel \
+    libxml2-devel \
+    perl-Devel-Peek \
+    perl-FreezeThaw \
+    perl-HTML-Parser \
+    perl-libwww-perl \
+    wget \
+    && yum clean all
 
 WORKDIR /headerdoc_build
-RUN dnf update -y \
-&& dnf install -y epel-release \
-&& dnf groupinstall -y "Development Tools" \
-&& dnf install -y \
-libxml2-devel \
-perl-HTML-Parser \
-perl-libwww-perl \
-perl-FreezeThaw \
-libxml2-devel \
-wget \
-perl-Devel-Peek \
-ruby-devel \
-rubygem-bundler \
-&& dnf clean all
 
 RUN wget https://opensource.apple.com/tarballs/headerdoc/headerdoc-8.9.5.tar.gz -qO- | tar xzf -
 WORKDIR headerdoc-8.9.5
@@ -23,5 +22,7 @@ RUN make realinstall
 
 COPY . /translator
 WORKDIR /translator
-RUN gem install bundler && bundle install --system
+
+RUN bundle install --system
+
 CMD ./translate

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,4 +18,4 @@ DEPENDENCIES
   nokogiri
 
 BUNDLED WITH
-   1.12.5
+   2.3.4

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Translates the SplashKit C++ source into another language.
 - [SplashKit Translator](#splashkit-translator)
 - [Contents](#contents)
 - [Running](#running)
+   - [Docker](#docker)
    - [Dependencies](#dependencies)
    - [Validating](#validating)
    - [Converting](#converting)
@@ -37,6 +38,10 @@ Translates the SplashKit C++ source into another language.
 <!-- /MDTOC -->
 
 # Running
+
+## Docker
+
+This project can be setup on any platform through the use of Docker containers. A docker file can be found in the root of the repository, information on how to get setup and running with can be found in [Docker_README.md](https://github.com/thoth-tech/splashkit-translator/blob/master/Docker_README.md)
 
 ## Dependencies
 


### PR DESCRIPTION
This commit uses the latest version of Centos 7 and Ruby 2.7 base image for Docker. The old image has been discontinued and caused breakage on build.

<details>
<summary>Error when running docker build</summary>

```sh
❯ docker build --tag headerdoc -f Dockerfile .
[+] Building 4.6s (8/15)                                                                          
 => [internal] load build definition from Dockerfile                                         0.0s
 => => transferring dockerfile: 640B                                                         0.0s
 => [internal] load .dockerignore                                                            0.0s
 => => transferring context: 2B                                                              0.0s
 => [internal] load metadata for docker.io/library/centos:centos8                            3.0s
 => [auth] library/centos:pull token for registry-1.docker.io                                0.0s
 => [internal] load build context                                                            0.0s
 => => transferring context: 50.43kB                                                         0.0s
 => [ 1/10] FROM docker.io/library/centos:centos8@sha256:a27fd8080b517143cbbbab9dfb7c8571c4  0.0s
 => CACHED [ 2/10] WORKDIR /headerdoc_build                                                  0.0s
 => ERROR [ 3/10] RUN dnf update -y && dnf install -y epel-release && dnf groupinstall -y "  1.5s
------
 > [ 3/10] RUN dnf update -y && dnf install -y epel-release && dnf groupinstall -y "Development Tools" && dnf install -y libxml2-devel perl-HTML-Parser perl-libwww-perl perl-FreezeThaw libxml2-devel wget perl-Devel-Peek ruby-devel rubygem-bundler && dnf clean all:
#7 1.457 CentOS Linux 8 - AppStream                       59  B/s |  38  B     00:00    
#7 1.463 Error: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist
------
executor failed running [/bin/sh -c dnf update -y && dnf install -y epel-release && dnf groupinstall -y "Development Tools" && dnf install -y libxml2-devel perl-HTML-Parser perl-libwww-perl perl-FreezeThaw libxml2-devel wget perl-Devel-Peek ruby-devel rubygem-bundler && dnf clean all]: exit code: 1
```
</details>

## How to test

- Check out the branch
- Make sure Docker Desktop is installed
- Build a new Docker image
  ```sh
  docker build --tag headerdoc -f Dockerfile .
  ```
- Run the translator using the above image
  ```sh
  docker run --rm -v /Users/tanle/Code/learn/thoth-tech/splashkit-core:/splashkit/ headerdoc ./translate -i /splashkit/ -o /splashkit/generated -g cpp,docs,clib,python,pascal,csharp

  Executing cpp translator...                                     
  Done!                                                           
  Output written!                                                 

  Executing docs translator...                                    
  Done!                                                           
  Output written!                                                 
  Place `api.json` in the `data` directory of the `splashkit.io` repo                                                             

  Executing clib translator...                                    
  Done!                                                           
  Output written!                                                 

  Executing python translator...                                  
  Done!                                                           
  Output written!                                                 

  Executing pascal translator...                                  
  Done!                                                           
  Output written!                                                 

  Executing csharp translator...                                  
  Done!                                                           
  Output written!    
  ```
Tested on macOS 12.3.1 (Monterey) and Docker version 20.10.13, build a224086