### PR TITLE
docs: Update SplashKit setup instructions with Docker_README

### DIFF
--- a/Docker_README.md
+++ b/Docker_README.md
@@ -1,6 +1,31 @@
+# Clone SplashKit Repositories
+1. Clone the SplashKit-Core Repository
+    git clone https://github.com/thoth-tech/splashkit-core.git
+
+2. Clone the SplashKit-Translator Repository
+    git clone https://github.com/thoth-tech/splashkit-translator.git
+
+# Install Docker
+https://docs.docker.com/engine/install/
+
+## Ubuntu
+```sh
+sudo apt-get update
+```
+```sh 
+sudo apt-get install docker-ce docker-ce-cli containerd.io
+```
+
 # To Build
-Run the following command in the translator directory
-` docker build --tag headerdoc -f Dockerfile .`
+
+Run the following command in the `splashkit-translator` root directory
+
+```sh
+docker build --tag headerdoc -f Dockerfile .
+```
 
 # To Run
-`docker run --rm -v <absolute path to splashkit-core>:/splashkit/ headerdoc ./translate -i /splashkit/ -o /splashkit/generated -g cpp,docs,clib,python,pascal,csharp`
+
+```sh
+docker run --rm -v <absolute path to splashkit-core>:/splashkit/ headerdoc ./translate -i /splashkit/ -o /splashkit/generated -g cpp,docs,clib,python,pascal,csharp
+```

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Translates the SplashKit C++ source into another language.
 - [SplashKit Translator](#splashkit-translator)
 - [Contents](#contents)
 - [Running](#running)
+   - [Docker](#docker)
    - [Dependencies](#dependencies)
    - [Validating](#validating)
    - [Converting](#converting)
@@ -37,6 +38,10 @@ Translates the SplashKit C++ source into another language.
 <!-- /MDTOC -->
 
 # Running
+
+## Docker
+
+This project can be setup on any platform through the use of Docker containers. A docker file can be found in the root of the repository, information on how to get setup and running with can be found in [Docker_README.md](https://github.com/thoth-tech/splashkit-translator/blob/master/Docker_README.md)
 
 ## Dependencies
 


### PR DESCRIPTION
Add reference to docker setup information to the main readme document. Add explicit steps to get the SplashKit translator project running with docker. Includes Ubunutu specific commands.