### PR TITLE
Simplify local develoment with docker compose

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-# Set all Ruby files to have LF line endings
-*.rb text eol=lf
+# Set all files to have LF line endings
+* text eol=lf

--- a/Docker_README.md
+++ b/Docker_README.md
@@ -1,18 +1,26 @@
 # Clone SplashKit Repositories
-1. Clone the SplashKit-Core Repository
-    git clone https://github.com/thoth-tech/splashkit-core.git
 
-2. Clone the SplashKit-Translator Repository
-    git clone https://github.com/thoth-tech/splashkit-translator.git
+1. Clone the `splashkit-core` repository
+
+   ```sh
+   git clone https://github.com/thoth-tech/splashkit-core.git
+   ```
+
+2. Clone the `splashkit-translator` repository
+
+   ```sh
+   git clone https://github.com/thoth-tech/splashkit-translator.git
+   ```
 
 # Install Docker
+
+Please follow the instructions from the official website
 https://docs.docker.com/engine/install/
 
 ## Ubuntu
+
 ```sh
 sudo apt-get update
-```
-```sh 
 sudo apt-get install docker-ce docker-ce-cli containerd.io
 ```
 
@@ -21,11 +29,34 @@ sudo apt-get install docker-ce docker-ce-cli containerd.io
 Run the following command in the `splashkit-translator` root directory
 
 ```sh
-docker build --tag headerdoc -f Dockerfile .
+docker compose build
 ```
 
 # To Run
 
+It is advisable to translate into a limited set of languages. Translating to all available languages
+will take some time to complete.
+
 ```sh
-docker run --rm -v <absolute path to splashkit-core>:/splashkit/ headerdoc ./translate -i /splashkit/ -o /splashkit/generated -g cpp,docs,clib,python,pascal,csharp
+docker compose run --rm headerdoc python,csharp
+
+Translating SplashKit Core to python,csharp
+Executing python translator...
+Done!
+Output written!
+
+Executing csharp translator...
+Done!
+Output written!
 ```
+
+By default, this expects the `splaskit-core` folder is located under the same
+location as the `splashkit-translator` folder.
+
+```sh
+.
+├── splashkit-core
+└── splashkit-translator
+```
+
+The translated code will be available under `splashkit-code/generated` folder on the host machine.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,6 @@ services:
     build: .
     stdin_open: true
     tty: true
-    entrypoint: /bin/sh /translator/translate_wrapper
+    entrypoint: /bin/bash /translator/translate_wrapper
     volumes:
       - ../splashkit-core:/splashkit

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,6 @@ services:
     build: .
     stdin_open: true
     tty: true
-    entrypoint: ./translate_wrapper
+    entrypoint: /bin/sh /translator/translate_wrapper
     volumes:
       - ../splashkit-core:/splashkit

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+---
+version: "3"
+services:
+  headerdoc:
+    container_name: headerdoc
+    build: .
+    stdin_open: true
+    tty: true
+    entrypoint: ./translate_wrapper
+    volumes:
+      - ../splashkit-core:/splashkit

--- a/translate_wrapper
+++ b/translate_wrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 set -eu
 

--- a/translate_wrapper
+++ b/translate_wrapper
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 set -eu
 

--- a/translate_wrapper
+++ b/translate_wrapper
@@ -5,7 +5,8 @@ set -eu
 translators="$1"
 
 echo "Translating SplashKit Core to ${translators}"
-./translate \
+
+./src/main.rb \
   -i /splashkit/ \
   -o /splashkit/generated \
   -g "$translators"

--- a/translate_wrapper
+++ b/translate_wrapper
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -eu
+
+translators="$1"
+
+echo "Translating SplashKit Core to ${translators}"
+./translate \
+  -i /splashkit/ \
+  -o /splashkit/generated \
+  -g "$translators"


### PR DESCRIPTION
This PR helps to simplify local development with `docker-compose`. This is a follow-up from @macite's [comment](https://github.com/thoth-tech/splashkit-translator/pull/2#issuecomment-1090075108) on https://github.com/thoth-tech/splashkit-translator/pull/2.

## How to test

- Check out the branch
- Make sure Docker Desktop is installed
- Build a new Docker image 
  ```sh
  docker compose build
  ```
- Run the translator using the above image
   ```sh
  docker compose run --rm headerdoc python,csharp
  
  Translating SplashKit Core to python,csharp
  Executing python translator...
  Done!
  Output written!
  
  Executing csharp translator...
  Done!
  Output written!
  ```


