### PR TITLE
docs: format docs and add code syntax highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,32 +9,32 @@ Translates the SplashKit C++ source into another language.
 - [SplashKit Translator](#splashkit-translator)
 - [Contents](#contents)
 - [Running](#running)
-   - [Docker](#docker)
-   - [Dependencies](#dependencies)
-   - [Known Issues](#known-issues)
-   - [Validating](#validating)
-   - [Converting](#converting)
+  - [Docker](#docker)
+  - [Dependencies](#dependencies)
+  - [Known Issues](#known-issues)
+  - [Validating](#validating)
+  - [Converting](#converting)
 - [SplashKit Documentation Guidelines](#splashkit-documentation-guidelines)
-   - [Header File Docblocks](#header-file-docblocks)
-   - [Function Docblocks](#function-docblocks)
-   - [Enum Docblocks](#enum-docblocks)
-   - [Struct Docblocks](#struct-docblocks)
-   - [Typedef Docblocks](#typedef-docblocks)
-   - [Attributes](#attributes)
-      - [`class`](#class)
-         - [Usage in typedefs](#usage-in-typedefs)
-         - [Usage in functions](#usage-in-functions)
-      - [`static`](#static)
-      - [`method`](#method)
-      - [`constructor`](#constructor)
-      - [`destructor`](#destructor)
-      - [`self`](#self)
-      - [`suffix`](#suffix)
-      - [`getter`](#getter)
-      - [`setter`](#setter)
-      - [`group`](#group)
-      - [`note`](#note)
-   - [Summary Rules](#summary-rules)
+  - [Header File Docblocks](#header-file-docblocks)
+  - [Function Docblocks](#function-docblocks)
+  - [Enum Docblocks](#enum-docblocks)
+  - [Struct Docblocks](#struct-docblocks)
+  - [Typedef Docblocks](#typedef-docblocks)
+  - [Attributes](#attributes)
+    - [`class`](#class)
+      - [Usage in typedefs](#usage-in-typedefs)
+      - [Usage in functions](#usage-in-functions)
+    - [`static`](#static)
+    - [`method`](#method)
+    - [`constructor`](#constructor)
+    - [`destructor`](#destructor)
+    - [`self`](#self)
+    - [`suffix`](#suffix)
+    - [`getter`](#getter)
+    - [`setter`](#setter)
+    - [`group`](#group)
+    - [`note`](#note)
+  - [Summary Rules](#summary-rules)
 
 <!-- /MDTOC -->
 
@@ -55,7 +55,7 @@ Ensure you have HeaderDoc installed:
 Install dependencies using `bundle`:
 
 ```bash
-$ bundle install
+bundle install
 ```
 
 Then run using `translate`.
@@ -76,7 +76,7 @@ To validate a single file or files, supply the `--validate` or `-v` switch and
 the `--input` or `-i` switch with the header file you wish to validate:
 
 ```bash
-$ ./translate --validate --input /path/to/splashkit/coresdk/src/coresdk/audio.h
+./translate --validate --input /path/to/splashkit/coresdk/src/coresdk/audio.h
 ```
 
 This will only _validate_ input that it can be correctly parsed, but will not
@@ -86,7 +86,7 @@ Alternatively, you can validate all header files by supplying just the
 SplashKit `coresdk/src/coresdk` directory instead:
 
 ```bash
-$ ./translate -v -i /path/to/splashkit/coresdk/src/coresdk
+./translate -v -i /path/to/splashkit/coresdk/src/coresdk
 ```
 
 ## Converting
@@ -97,7 +97,7 @@ comma-separated list under the `--generate` or `-g` switch and specifying the
 output directory using the `--output` or `-o` switch:
 
 ```bash
-$ ./translate -i /path/to/splashkit -o ~/Desktop/translated -g YAML,SKLIBC,CPP
+./translate -i /path/to/splashkit -o ~/Desktop/translated -g YAML,SKLIBC,CPP
 ```
 
 If no output directory is used, then it will default to an `out/translated`
@@ -155,18 +155,19 @@ A function docblock should consist of _at least_ a basic description of the
 functionality provided by the function in Markdown. Where applicable, it also
 must have:
 
-* `@param [name] [description]` - The name and description of a parameter.
+- `@param [name] [description]` - The name and description of a parameter.
   These should be listed in order of the function's signature. **All parameters
   must be listed and be consistent with the correct name(s) in the signature.**
-* `@returns [description]` - A basic description of what is returned from the
+- `@returns [description]` - A basic description of what is returned from the
   function. **Any non-void function must have an `@returns`**.
-* `@brief [description]` - A brief, one sentence description of what
+- `@brief [description]` - A brief, one sentence description of what
   functionality is added in this function.
 
 Each of the above should be separated with a newline and grouped together where
 applicable.
 
 Example, `load_sound_effect`:
+
 ```c
 /**
  * @brief Loads and returns a sound effect.
@@ -500,25 +501,25 @@ either:
 <a id="pr4-instance-getter"></a>
 <a id="pr2-static-getter"></a>
 
-* `class` and `self` to make an _instance_ getter on the an instance whose class
-   is specified by `class`, or
-* `static` to make a _static_ getter on the class specified `static`.
+- `class` and `self` to make an _instance_ getter on the an instance whose class
+  is specified by `class`, or
+- `static` to make a _static_ getter on the class specified `static`.
 
 Must be set on a function that:
 
 <a id="pr9-getter"></a>
 
-* has __exactly__ _zero_ or _one_ parameters, depending on if you are using
+- has **exactly** _zero_ or _one_ parameters, depending on if you are using
   `class` or `static`, and
-* is non-void.
+- is non-void.
 
 <a id="pr12-getter"></a>
-If you are writing a __`static`__ getter, then there must be no parameters.
+If you are writing a **`static`** getter, then there must be no parameters.
 
 <a id="pr6-getter"></a>
 <a id="pr10-getter"></a>
-If you are writing a __`class`__ setter, then you will need __exactly _one_
-parameter__, that being the parameter which will be used as `self`. You must
+If you are writing a **`class`** setter, then you will need **exactly _one_
+parameter**, that being the parameter which will be used as `self`. You must
 not specify that the function also a `method` (unless `static` is also supplied)
 or a `constructor` or `destructor`.
 
@@ -559,23 +560,22 @@ either:
 <a id="pr4-instance-setter"></a>
 <a id="pr2-static-setter"></a>
 
-* `class` and `self` to make an _instance_ setter on the an instance whose class
-   is specified by `class`, or
-* `static` to make a _static_ setter on the class specified `static`.
+- `class` and `self` to make an _instance_ setter on the an instance whose class
+  is specified by `class`, or
+- `static` to make a _static_ setter on the class specified `static`.
 
-
-Must be set on a function that has __exactly__ _one_ or _two_ parameters, which
+Must be set on a function that has **exactly** _one_ or _two_ parameters, which
 depends on if you are using `class` or `static`.
 
 <a id="pr13-setter"></a>
-If you are writing a __`static`__ setter, then you will need __exactly one
-parameter__, being the the second must the value that is to be set.
+If you are writing a **`static`** setter, then you will need **exactly one
+parameter**, being the second must the value that is to be set.
 
 <a id="pr11-setter"></a>
-If you are writing a __`class`__ setter, then you will need __exactly _two_
-parameters__, where:
+If you are writing a **`class`** setter, then you will need **exactly _two_
+parameters**, where:
 
-1. the first must be the the parameter which will be used as `self`, and
+1. the first must be the parameter which will be used as `self`, and
 2. the second must the value that is to be set.
 
 <a id="pr6-setter"></a>
@@ -616,9 +616,9 @@ Applicable only to header file HeaderDoc blocks. The value associated to group
 means that this particular header file is `group`ed under the group specified
 by this attribute. Related header files may be applicable to just the one, e.g.:
 
-* `audio.h`,
-* `sound_effect.h`, and
-* `music.h`
+- `audio.h`,
+- `sound_effect.h`, and
+- `music.h`
 
 could all be `group`ed under the `Audio` group.
 
@@ -674,9 +674,9 @@ for reference to this list.
    Attributes marked with `method`, `getter` or `setter` must be marked with
    either:
 
-    (i) **`class`** to make it an [instance method](#pr2-instance-method), [instance getter](#pr2-instance-getter) or [instance setter](#pr2-instance-setter) on _instance_ of that class, or
+   (i) **`class`** to make it an [instance method](#pr2-instance-method), [instance getter](#pr2-instance-getter) or [instance setter](#pr2-instance-setter) on _instance_ of that class, or
 
-    (ii) **`static`** to make it a [static method](#pr2-static-method), [static getter](#pr2-static-getter) or [static setter](#pr2-static-setter) on a class or module indicated by static.
+   (ii) **`static`** to make it a [static method](#pr2-static-method), [static getter](#pr2-static-getter) or [static setter](#pr2-static-setter) on a class or module indicated by static.
 
 3. <a id="rule-3"></a>
    There can never be both [`constructor`](#pr3-constructor) and
@@ -691,7 +691,7 @@ for reference to this list.
    destructor of that instance by the _one_ function.
 5. <a id="rule-5"></a>
    You cannot supply [`constructor`](#pr5-constructor) or
-   [`destructor`](#pr5-destructor)  and `method` unless
+   [`destructor`](#pr5-destructor) and `method` unless
    `static` is also supplied. This will make a static method on
    the class or module specified by static but a destructor/constructor on
    the class indicated by `class`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,16 +1,20 @@
 # SplashKit Translator
 
 ## Summary
-The SplashKit translator is a Ruby application that translates C++ input files (*.h) into a target language. The translator outputs a file in the target language that provides an interface between the target language and the SplashKit library. This file needs to be included as a reference/import/header in your project and allows access to the SplashKit methods. This provides a link to the SplashKit installation on the current machine. To a SplashKit project via a translated langauge SplashKit _must_ be installed.
+
+The SplashKit translator is a Ruby application that translates C++ input files (\*.h) into a target language. The translator outputs a file in the target language that provides an interface between the target language and the SplashKit library. This file needs to be included as a reference/import/header in your project and allows access to the SplashKit methods. This provides a link to the SplashKit installation on the current machine. To a SplashKit project via a translated langauge SplashKit _must_ be installed.
 
 ## Contents
+
 Current supported languages are:
+
 - C#
 - Pascal
 - Python
-- [Rust](/Rust/README.md)
+- [Rust](rust/README.md)
 
 ## Usage
+
 1. Install [SplashKit](SplashKit.io)
 2. Clone SplashKit-translator and SplashKit-core repositories
 3. Translate SplashKit-Core libraries to target language.
@@ -22,17 +26,9 @@ Current supported languages are:
 
 This project can be setup on any platform through the use of Docker containers. A docker file can be found in the root of the repository, information on how to get setup and running with can be found in [Docker_README.md](https://github.com/thoth-tech/splashkit-translator/blob/master/Docker_README.md)
 
-
 ## Project Structure
 
-__splashkit-translator/core_ext__
-Ruby extensions nokogiri, array and string
-
-__splashkit-translator/res__
-Ruby template files for language translator. Contain hardcoded syntax and structure for the translated contents to be inserted into.
-
-__splashkit-translator/src__
-The core Ruby translator project. The Ruby translator parses the input files, converts to the target language, inserts into Ruby templates and saves to output location.
-
-__splashkit-translator/docs__
-All documentation about the SplashKit Translator project.
+- **splashkit-translator/core_ext**: Ruby extensions nokogiri, array and string
+- **splashkit-translator/res**: Ruby template files for language translator. Contain hardcoded syntax and structure for the translated contents to be inserted into.
+- **splashkit-translator/src**: The core Ruby translator project. The Ruby translator parses the input files, converts to the target language, inserts into Ruby templates and saves to output location.
+- **splashkit-translator/docs**: All documentation about the SplashKit Translator project.

--- a/docs/rust/README.md
+++ b/docs/rust/README.md
@@ -1,33 +1,47 @@
 # Rust Usage
 
 ## Summary
-This article covers how to setup Rust, import and link the Splashkit.rs file and start development.
+
+This article covers how to setup Rust, import and link the `splashkit.rs` file and start development.
 
 ## Setup Rust
+
 ### Ubuntu
+
 #### Install Rust
-- curl https://sh.rustup.rs -sSf | sh
-- source $HOME/.cargo/env
-### Install Cmake
-- sudo apt install build-essential
-- sudo apt install cmake
+
+```shell
+curl https://sh.rustup.rs -sSf | sh
+
+source $HOME/.cargo/env
+```
+
+#### Install Cmake
+
+```shell
+sudo apt install build-essential cmake
+```
 
 ## Linking the library
 
-Create a reference to the splashkit.rs file. Note the directory is relative to the current folder directory.
-```Rust
+Create a reference to the `splashkit.rs` file. Note the directory is relative to the current folder directory.
+
+```rust
 #[path = "./splashkit-core/generated/rust/splashkit.rs"]
 ```
 
 Reference the module that will be used.
-```Rust
+
+```rust
 mod splashkit;
 ```
 
 Add a using statement so you do not require referencing the module repeatedly.
-```Rust
+
+```rust
 use splashkit::say_yay();
 ```
 
 ## Test
+
 TBC


### PR DESCRIPTION
- Format all docs using [`prettier`](https://prettier.io/)
- Add missing code syntax highlight on Rust document
- Remove redundant shell prompt on commands