### PR TITLE
Modify Csharp Templates

### DIFF
--- a/res/translators/csharp/SplashKit/classes/resource_classes.cs.erb
+++ b/res/translators/csharp/SplashKit/classes/resource_classes.cs.erb
@@ -15,11 +15,6 @@ public class <%= class_name %> : PointerWrapper
 {
   private <%= class_name %>(IntPtr ptr) : base(ptr, true) {}
 
-  /// <summary>
-  /// Fetches or creates an instance of <%= class_name %> from the given pointer.
-  /// </summary>
-  /// <param name="ptr">The pointer to the SplashKit resource.</param>
-  /// <returns>An instance of <%= class_name %>.</returns>
   internal static <%= class_name %> FetchOrCreate(IntPtr ptr)
   {
     #pragma warning disable CS8603
@@ -67,9 +62,6 @@ public static class <%= class_name %>
       fn = the_class[:destructor]
       method_data = get_method_data(fn)
 %>
-    /// <summary>
-    /// Frees the resources held by this instance of <%= class_name %>.
-    /// </summary>
     protected internal override void DoFree()
     {
         SplashKit.<%= fn[:name].function_case %>(this);

--- a/res/translators/csharp/SplashKit/classes/resource_classes.cs.erb
+++ b/res/translators/csharp/SplashKit/classes/resource_classes.cs.erb
@@ -3,15 +3,23 @@
 %>
 
 <%
-  @classes.select{ |k, c| ! c[:is_struct] }.each do | class_id, the_class |
+  @classes.select { |k, c| !c[:is_struct] }.each do |class_id, the_class|
     class_name = class_id.to_s.to_pascal_case
 
     if the_class[:is_alias]
 %>
+/// <summary>
+/// This class represents <%= class_name %>, which wraps a pointer to SplashKit resources.
+/// </summary>
 public class <%= class_name %> : PointerWrapper
 {
   private <%= class_name %>(IntPtr ptr) : base(ptr, true) {}
 
+  /// <summary>
+  /// Fetches or creates an instance of <%= class_name %> from the given pointer.
+  /// </summary>
+  /// <param name="ptr">The pointer to the SplashKit resource.</param>
+  /// <returns>An instance of <%= class_name %>.</returns>
   internal static <%= class_name %> FetchOrCreate(IntPtr ptr)
   {
     #pragma warning disable CS8603
@@ -21,7 +29,11 @@ public class <%= class_name %> : PointerWrapper
     #pragma warning restore CS8603
     return new <%= class_name %>(ptr);
   }
+
 <% else %>
+/// <summary>
+/// Static methods for working with <%= class_name %> in the SplashKit framework.
+/// </summary>
 public static class <%= class_name %>
 {
 <%
@@ -40,39 +52,54 @@ public static class <%= class_name %>
     the_class[:constructors].each do |fn|
       method_data = get_method_data(fn)
 %>
-
-    public <%= class_name %>(<%= method_data[:params] %>) : base ( SplashKit.<%= fn[:name].function_case %>(<%= method_data[:args] %>), false )
+    /// <summary>
+    /// Creates a new instance of <%= class_name %> using the provided parameters.
+    /// </summary>
+<% fn[:parameters].each do |param_name, param_data| %>
+    /// <param name="<%= param_name %>"> <%= (param_data[:description] || "").gsub("\n", " ") %></param>
+<% end %>
+    public <%= class_name %>(<%= method_data[:params] %>) : base(SplashKit.<%= fn[:name].function_case %>(<%= method_data[:args] %>), false)
     { }
 <%
-    end # constructors each
+    end # constructors.each
 
-    # Add constructors
     if the_class[:destructor]
       fn = the_class[:destructor]
       method_data = get_method_data(fn)
 %>
+    /// <summary>
+    /// Frees the resources held by this instance of <%= class_name %>.
+    /// </summary>
     protected internal override void DoFree()
     {
-        // System.Console.WriteLine("TODO: Free!");
         SplashKit.<%= fn[:name].function_case %>(this);
     }
 <%
     elsif the_class[:no_destructor]
     %>
-        protected internal override void DoFree()
-        {}
-    <%
-    end #destructor
+    protected internal override void DoFree()
+    {}
+<%
+    end # destructor
 
     # Add methods
     the_class[:methods].each do |fn|
       method_data = get_method_data(fn)
       return_type = is_func?(fn) ? sk_type_for(fn[:return]) : 'void'
 %>
-
+    /// <summary>
+    /// Calls the <%= fn[:name].to_s.to_pascal_case %> method for <%= class_name %>.
+    /// <%= (fn[:description] || "").gsub("\n", " ") %>
+    /// </summary>
+<% fn[:parameters].each do |param_name, param_data| %>
+    /// <param name="<%= param_name %>"> <%= (param_data[:description] || "").gsub("\n", " ") %></param>
+<% end %>
+<% if is_func?(fn) %>
+    /// <returns><%= (fn[:return][:description] || "").gsub("\n", " ") %>.</returns>
+<% end %>
     public <%= method_data[:static] %><%= return_type %> <%= fn[:attributes][:method].function_case %>(<%= method_data[:params] %>)
     {
-<%      if is_func? fn %>
+<%      if is_func?(fn) %>
         return SplashKit.<%= fn[:name].function_case %>(<%= method_data[:args] %>);
 <%      else %>
         SplashKit.<%= fn[:name].function_case %>(<%= method_data[:args] %>);
@@ -82,18 +109,20 @@ public static class <%= class_name %>
 <%
     end # methods
 
-    the_class[:properties].each do | property_name, property |
+    the_class[:properties].each do |property_name, property|
       if property[:getter]
         property_type = sk_type_for(property[:getter][:return])
         method_data = get_method_data(property[:getter])
       else
-        property_type = sk_type_for(property[:setter][:parameters].select { |k,v| v[:type] != the_class[:name] }.map { |k,v| v }.first)
+        property_type = sk_type_for(property[:setter][:parameters].select { |k, v| v[:type] != the_class[:name] }.map { |k, v| v }.first)
         method_data = get_method_data(property[:setter])
       end
 
 %>
+    /// <summary>
+    /// Gets or sets the <%= property_name.to_s.to_pascal_case %> property of the <%= class_name %>.
+    /// </summary>
     public <%= method_data[:static] %><%= property_type %> <%= property_name.to_s.to_pascal_case %>
-
     {
 <%
       if property[:getter]
@@ -112,9 +141,9 @@ public static class <%= class_name %>
         method_data = get_method_data(fn)
         if method_data[:static].nil?
 %>
-          set { SplashKit.<%= fn[:name].function_case %>(this, value); }
+        set { SplashKit.<%= fn[:name].function_case %>(this, value); }
 <%      else %>
-          set { SplashKit.<%= fn[:name].function_case %>(value); }
+        set { SplashKit.<%= fn[:name].function_case %>(value); }
 <%
         end
       end

--- a/res/translators/csharp/SplashKit/classes/resource_classes.cs.erb
+++ b/res/translators/csharp/SplashKit/classes/resource_classes.cs.erb
@@ -51,7 +51,7 @@ public static class <%= class_name %>
     /// Creates a new instance of <%= class_name %> using the provided parameters.
     /// </summary>
 <% fn[:parameters].each do |param_name, param_data| %>
-    /// <param name="<%= param_name %>"> <%= (param_data[:description] || "").gsub("\n", " ") %></param>
+    /// <param name="<%= param_name.variable_case %>"> <%= (param_data[:description] || "").gsub("\n", " ") %></param>
 <% end %>
     public <%= class_name %>(<%= method_data[:params] %>) : base ( SplashKit.<%= fn[:name].function_case %>(<%= method_data[:args] %>), false )
     { }
@@ -83,8 +83,10 @@ public static class <%= class_name %>
     /// <%= (fn[:description] || "").gsub("\n", " ") %>
 
     /// </summary>
-<% fn[:parameters].each do |param_name, param_data| %>
-    /// <param name="<%= param_name %>"> <%= (param_data[:description] || "").gsub("\n", " ") %></param>
+<% fn[:parameters].select { |param_name|
+        param_name.to_s != fn[:attributes][:self]
+    }.each do |param_name, param_data| %>
+    /// <param name="<%= param_name.variable_case %>"> <%= (param_data[:description] || "").gsub("\n", " ") %></param>
 <% end %>
 <% if is_func?(fn) %>
     /// <returns><%= (fn[:return][:description] || "").gsub("\n", " ") %>.</returns>

--- a/res/translators/csharp/SplashKit/classes/resource_classes.cs.erb
+++ b/res/translators/csharp/SplashKit/classes/resource_classes.cs.erb
@@ -89,7 +89,7 @@ public static class <%= class_name %>
     /// <param name="<%= param_name.variable_case %>"> <%= (param_data[:description] || "").gsub("\n", " ") %></param>
 <% end %>
 <% if is_func?(fn) %>
-    /// <returns><%= (fn[:return][:description] || "").gsub("\n", " ") %>.</returns>
+    /// <returns><%= (fn[:return][:description] || "").gsub("\n", " ") %></returns>
 <% end %>
     public <%= method_data[:static] %><%= return_type %> <%= fn[:attributes][:method].function_case %>(<%= method_data[:params] %>)
     {

--- a/res/translators/csharp/SplashKit/classes/resource_classes.cs.erb
+++ b/res/translators/csharp/SplashKit/classes/resource_classes.cs.erb
@@ -53,7 +53,7 @@ public static class <%= class_name %>
 <% fn[:parameters].each do |param_name, param_data| %>
     /// <param name="<%= param_name %>"> <%= (param_data[:description] || "").gsub("\n", " ") %></param>
 <% end %>
-    public <%= class_name %>(<%= method_data[:params] %>) : base(SplashKit.<%= fn[:name].function_case %>(<%= method_data[:args] %>), false)
+    public <%= class_name %>(<%= method_data[:params] %>) : base ( SplashKit.<%= fn[:name].function_case %>(<%= method_data[:args] %>), false )
     { }
 <%
     end # constructors.each
@@ -80,8 +80,8 @@ public static class <%= class_name %>
       return_type = is_func?(fn) ? sk_type_for(fn[:return]) : 'void'
 %>
     /// <summary>
-    /// Calls the <%= fn[:name].to_s.to_pascal_case %> method for <%= class_name %>.
     /// <%= (fn[:description] || "").gsub("\n", " ") %>
+
     /// </summary>
 <% fn[:parameters].each do |param_name, param_data| %>
     /// <param name="<%= param_name %>"> <%= (param_data[:description] || "").gsub("\n", " ") %></param>
@@ -115,6 +115,7 @@ public static class <%= class_name %>
     /// Gets or sets the <%= property_name.to_s.to_pascal_case %> property of the <%= class_name %>.
     /// </summary>
     public <%= method_data[:static] %><%= property_type %> <%= property_name.to_s.to_pascal_case %>
+
     {
 <%
       if property[:getter]

--- a/res/translators/csharp/SplashKit/methods.cs.erb
+++ b/res/translators/csharp/SplashKit/methods.cs.erb
@@ -16,8 +16,17 @@
 %>
 <%
   @functions.each do |function|
-    is_constructor = ! function[:attributes][:constructor].nil?
+    is_constructor = !function[:attributes][:constructor].nil?
 %>
+    /// <summary>
+    /// <%= (function[:description] || "").gsub("\n", " ") %> 
+    /// </summary>
+<% function[:parameters].each do |param_name, param_data| %>
+    /// <param name="<%= param_name %>"> <%= (param_data[:description] || "").gsub("\n", " ") %></param>
+<% end %>
+<% if is_func?(function) %>
+    /// <returns><%= (function[:return][:description] || "").gsub("\n", " ") %>.</returns>
+<% end %>
     <%= sk_signature_for(function) %>
 
     {
@@ -74,17 +83,17 @@
 %>
       <%= param_name.variable_case %> = <%= sk_mapper_fn_for param_data %>(__skparam__<%= param_name %>);
 <%
-      end # end if is non const ref
+      end # end if is non-const ref
     end # end parameters.each
 %>
 <%#
     4. Free any string or vector parameters
 %>
 <%
-    params_to_free = function[:parameters].select do | _, param_data |
+    params_to_free = function[:parameters].select do |_, param_data|
       param_data[:type] == 'string' || param_data[:is_vector]
     end # end select
-    params_to_free.each do | param_name, param_data |
+    params_to_free.each do |param_name, param_data|
       type_name = lib_type_for(param_data)
 %>
     __skadapter__free<%=type_name%>(ref __skparam__<%=param_name%>);

--- a/res/translators/csharp/SplashKit/methods.cs.erb
+++ b/res/translators/csharp/SplashKit/methods.cs.erb
@@ -19,13 +19,14 @@
     is_constructor = !function[:attributes][:constructor].nil?
 %>
     /// <summary>
-    /// <%= (function[:description] || "").gsub("\n", " ") %> 
+    /// <%= (function[:description] || "").gsub("\n", " ") %>
+
     /// </summary>
 <% function[:parameters].each do |param_name, param_data| %>
     /// <param name="<%= param_name %>"> <%= (param_data[:description] || "").gsub("\n", " ") %></param>
 <% end %>
 <% if is_func?(function) %>
-    /// <returns><%= (function[:return][:description] || "").gsub("\n", " ") %>.</returns>
+    /// <returns><%= (function[:return][:description] || "").gsub("\n", " ") %></returns>
 <% end %>
     <%= sk_signature_for(function) %>
 

--- a/res/translators/csharp/SplashKit/methods.cs.erb
+++ b/res/translators/csharp/SplashKit/methods.cs.erb
@@ -23,7 +23,7 @@
 
     /// </summary>
 <% function[:parameters].each do |param_name, param_data| %>
-    /// <param name="<%= param_name %>"> <%= (param_data[:description] || "").gsub("\n", " ") %></param>
+    /// <param name="<%= param_name.variable_case %>"> <%= (param_data[:description] || "").gsub("\n", " ") %></param>
 <% end %>
 <% if is_func?(function) %>
     /// <returns><%= (function[:return][:description] || "").gsub("\n", " ") %></returns>


### PR DESCRIPTION
# Description

When generating the C# wrapper for SplashKit, it would be nice for the translator to also generate C#'s XML based documentation comments from the existing HeaderDoc comments. I've firstly work on another pull request and from the review I put the pull request to the wrong repo, here's the link to the closed pull request: https://github.com/splashkit/splashkit-translator/pull/58


## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I had to modify the csharp templates using the ERB templating system. I modify the code so it correctly inputs the XML comments into splashkit.cs.

## Testing Checklist

- [ ] Tested with sktest
- [ ] Tested with skunit_tests

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request
