### PR TITLE
Fix/update docker container

### DIFF
--- a/Docker_README.md
+++ b/Docker_README.md
@@ -41,7 +41,7 @@ It is advisable to translate into a limited set of languages. Translating to all
 will take some time to complete.
 
 ```sh
-docker compose run --rm headerdoc cliv,cpp,pascal,python,csharp,docs
+docker compose run --rm headerdoc clib,cpp,pascal,python,csharp,docs
 
 Translating SplashKit Core to clib,cpp,pascal,python,csharp,docs
 Executing clib translator...

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,7 @@ RUN wget https://opensource.apple.com/tarballs/headerdoc/headerdoc-8.9.31.tar.gz
 WORKDIR headerdoc-headerdoc-8.9.31
 
 WORKDIR xmlman
-RUN sed -i 's/^xml2man: xml2man.o \(.*\)$/xml2man: xml2man.o \1\n\t$(CC) -o $@ $^ $(LDFLAGS)/' Makefile && \
-    sed -i 's/^hdxml2manxml: hdxml2manxml.o \(.*\)$/hdxml2manxml: hdxml2manxml.o \1\n\t$(CC) -o $@ $^ $(LDFLAGS)/' Makefile && \
-    sed -i 's/^resolveLinks: resolveLinks.o \(.*\)$/resolveLinks: resolveLinks.o \1\n\t$(CC) -o $@ $^ $(LDFLAGS)/' Makefile
+RUN sed -i 's/^xml2man: xml2man.o \(.*\)$/xml2man: xml2man.o \1\n\t$(CC) -o $@ $^ $(LDFLAGS)/' Makefile 
 
 WORKDIR ..
 RUN make realinstall

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,39 @@
-FROM centos/ruby-27-centos7:2.7
+FROM almalinux:9 
 
 USER 0
 
 RUN yum update -y \
+    && yum install -y epel-release \
     && yum install -y \
+    make \
+    gcc \
+    which \
     libxml2-devel \
+    perl-core \
     perl-Devel-Peek \
     perl-FreezeThaw \
     perl-HTML-Parser \
     perl-libwww-perl \
     wget \
+    ruby \
+    ruby-devel \
+    rubygems \
     && yum clean all
+
+RUN gem install bundler
 
 WORKDIR /headerdoc_build
 
 RUN wget https://opensource.apple.com/tarballs/headerdoc/headerdoc-8.9.31.tar.gz -qO- | tar xzf -
 
 WORKDIR headerdoc-headerdoc-8.9.31
+
+WORKDIR xmlman
+RUN sed -i 's/^xml2man: xml2man.o \(.*\)$/xml2man: xml2man.o \1\n\t$(CC) -o $@ $^ $(LDFLAGS)/' Makefile && \
+    sed -i 's/^hdxml2manxml: hdxml2manxml.o \(.*\)$/hdxml2manxml: hdxml2manxml.o \1\n\t$(CC) -o $@ $^ $(LDFLAGS)/' Makefile && \
+    sed -i 's/^resolveLinks: resolveLinks.o \(.*\)$/resolveLinks: resolveLinks.o \1\n\t$(CC) -o $@ $^ $(LDFLAGS)/' Makefile
+
+WORKDIR ..
 RUN make realinstall
 
 COPY . /translator

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,25 +2,24 @@ FROM almalinux:9
 
 USER 0
 
-RUN yum update -y \
-    # epel-release contains most of the required perl dependencies
-    # The duplicate commands, such as perl-FreezeThaw, are kept so that we have a record of the specific libraries needed. 
-    && yum install -y epel-release \
-    && yum install -y \
+RUN dnf update -y \
+    && dnf install -y \
     make \
     gcc \
     which \
     libxml2-devel \
     perl-core \
     perl-Devel-Peek \
-    perl-FreezeThaw \
     perl-HTML-Parser \
     perl-libwww-perl \
     wget \
     ruby \
     ruby-devel \
     rubygems \
-    && yum clean all
+    cpan \ 
+    && dnf clean all
+
+RUN cpan -i FreezeThaw
 
 RUN gem install bundler
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM almalinux:9
 USER 0
 
 RUN yum update -y \
+    # epel-release contains most of the required perl dependencies
+    # The duplicate commands, such as perl-FreezeThaw, are kept so that we have a record of the specific libraries needed. 
     && yum install -y epel-release \
     && yum install -y \
     make \
@@ -29,6 +31,7 @@ RUN wget https://opensource.apple.com/tarballs/headerdoc/headerdoc-8.9.31.tar.gz
 WORKDIR headerdoc-headerdoc-8.9.31
 
 WORKDIR xmlman
+# This command finds the xml2man build command and appends the linking flags at the end. This is not done already, for some reason.
 RUN sed -i 's/^xml2man: xml2man.o \(.*\)$/xml2man: xml2man.o \1\n\t$(CC) -o $@ $^ $(LDFLAGS)/' Makefile 
 
 WORKDIR ..

--- a/docs/scripts/CheckFileDifferences.sh
+++ b/docs/scripts/CheckFileDifferences.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Check if two arguments are provided
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <directory1> <directory2>"
+    exit 1
+fi
+
+DIR1="$1"
+DIR2="$2"
+
+find "$DIR1" -type f | while read -r file; do
+    file_in_dir2="${file/$DIR1/$DIR2}"
+
+    if [ -f "$file_in_dir2" ]; then
+        if ! diff -q "$file" "$file_in_dir2" > /dev/null; then
+            echo "Files Differ: $file and $file_in_dir2"
+        else
+            echo "Files Match: $file and $file_in_dir2"
+        fi
+    else
+        echo "File missing in $DIR2: $file_in_dir2"
+    fi
+done

--- a/docs/scripts/README.md
+++ b/docs/scripts/README.md
@@ -1,0 +1,12 @@
+## Directory Comparison Script
+
+This bash script compares files in two directories and checks if the files differ between them. 
+It uses `diff` to compare the content of the files in two directories and reports whether files are missing or different.
+
+## Usage
+
+To run the script, provide two directory paths as arguments:
+
+```bash
+./CheckFileDifferences.sh /path/to/directory1 /path/to/directory2
+```


### PR DESCRIPTION
This pull request updates the splashkit-translator Dockerfile from CentOS 7 to AlmaLinux 9 for better support and maintainability, reflecting CentOS 7’s deprecation. AlmaLinux was chosen as it "fills the gap left by the discontinuation of the CentOS Linux stable release." [See here.](https://almalinux.org/)

Key Changes:

- Base Image migration to AlmaLinux 9
- Updated package manager from `yum` to its successor `dnf`
- Modified the packaging to suit the new OS environment, ensuring compatibility and proper functionality.
- Fixed building of `xml2man` through appending linker flags to ensure proper compilation.
- Fixed small typo in Docker documentation.

Additionally, I have included the script used to compare the output of this new version with previous versions for verification purposes.

See the following file for an example of the output and evidence for the changes made here.
[FileDifferences.txt](https://github.com/user-attachments/files/17009575/FileDifferences.txt)

In this output 2 files differ, `api.json` and `translator_cache.json`. The differences for these are:
- `api.json`: The order of the array containing function signatures differs between versions. This is not a problem, as the splashkit.io website defines its own ordering.
- `translator_cache.json`: The only difference is the timestamp, which is expected and does not affect functionality.