### PR TITLE
Fix/handle negative enums

### DIFF
--- a/src/parser.rb
+++ b/src/parser.rb
@@ -790,7 +790,14 @@ class Parser::HeaderFileParser
           next unless next_el
           if next_el.name == 'declaration_number'
             # Is the constant negative?
-            minus_sign = (parsed.next_sibling&.text&.strip&.[](-1)) == '-' ? -1 : 1
+            # Generally, next_sibling will contain '='which assigns the number to
+            # a particular enum. 
+            # When this is negative next_sibling will be of the form '= -'. 
+            # So if  next_sibling exists and has text, we need to check the last 
+            # character and if it's a negative sign then we assign -1 and correct 
+            # the enums value when we assign it in the next line.
+            # The & ensures the value at that point is not nil.
+            minus_sign = (parsed.next_sibling&.text&.strip[-1]) == '-' ? -1 : 1
             # This number matches the constant
             constants[constant_name][:number] = next_el.text.to_i * minus_sign
           end

--- a/src/parser.rb
+++ b/src/parser.rb
@@ -789,8 +789,10 @@ class Parser::HeaderFileParser
           next_el = result[i+1]
           next unless next_el
           if next_el.name == 'declaration_number'
+            # Is the constant negative?
+            minus_sign = (parsed.next_sibling&.text&.strip&.[](-1)) == '-' ? -1 : 1
             # This number matches the constant
-            constants[constant_name][:number] = next_el.text.to_i
+            constants[constant_name][:number] = next_el.text.to_i * minus_sign
           end
         end
       end

--- a/src/parser.rb
+++ b/src/parser.rb
@@ -790,23 +790,19 @@ class Parser::HeaderFileParser
           next unless next_el
           if next_el.name == 'declaration_number'
             # Is the constant negative?
-            # Generally, next_sibling will contain '='which assigns the number to
-            # a particular enum. 
-            # When this is negative next_sibling will be of the form '= -'. 
-            # So if  next_sibling exists and has text, we need to check the last 
-            # character and if it's a negative sign then we assign -1 and correct 
-            # the enums value when we assign it in the next line.
-            # The & ensures the value at that point is not nil.
-            minus_sign = (parsed.next_sibling&.text&.strip[-1]) == '-' ? -1 : 1
+            # If it is negative next_sibling's last char will be '-'
             # This number matches the constant
-            constants[constant_name][:number] = next_el.text.to_i * minus_sign
+            if parsed.next_sibling.text.strip[-1] == '-'
+              constants[constant_name][:number] = next_el.text.to_i * -1 
+            else
+              constants[constant_name][:number] = next_el.text.to_i
+            end
           end
         end
       end
     end
     constants
   end
-
   #
   # Parse a single enum constant data
   #


### PR DESCRIPTION
There is an issue with SplashKit translator, in that it incorrectly parses negative enumerations as positive values. 

For an example, look at `GPIO_DEFAULT_VALUE` on SplashKit.io ([https://splashkit.io/api/types/#pin-values](https://splashkit.io/api/types/#pin-values)) versus how it's defined in `types.h` ([https://github.com/splashkit/splashkit-core/blob/aece11bfaff210c1d4afdd1d65f6a4c14766d542/coresdk/src/coresdk/types.h#L445](https://github.com/splashkit/splashkit-core/blob/aece11bfaff210c1d4afdd1d65f6a4c14766d542/coresdk/src/coresdk/types.h#L445))

The information on SplashKit.io is generated through the translator and as you can see it's incorrectly parsing `GPIO_DEFAULT_VALUE` as 1 instead of -1. This fixes the issue by finding the negative symbol, as it still exists in the parsed information, and modifying the enumeration values accordingly.