### PR TITLE
Added equality and inequality operators for cpp

### DIFF
--- a/res/translators/cpp/interface/types/struct.h.erb
+++ b/res/translators/cpp/interface/types/struct.h.erb
@@ -19,6 +19,21 @@ typedef struct {
     end # end fields.each
 %>
 } <%= struct[:name] %>;
+
+inline bool operator==(const <%= struct[:name] %>& lhs, const <%= struct[:name] %>& rhs) {
+    return 
+<%  struct[:fields].each_with_index do |(field_name, field_data), idx|
+      is_last = idx == struct[:fields].length - 1
+      sk_comparison_for(field_name, field_data, is_last).each do |comparison| %>
+        <%= comparison %><%= "\n" %>
+<%    end %>
+<%  end %>
+}
+
+inline bool operator!=(const <%= struct[:name] %>& lhs, const <%= struct[:name] %>& rhs) {
+    return !(lhs == rhs);
+}
+
 <%
     end # end struct.each
 %>

--- a/src/translators/cpp.rb
+++ b/src/translators/cpp.rb
@@ -166,5 +166,29 @@ module Translators
       # Just use clib SK adapter -- it's the same thing
       @clib.sk_update_fn_for(function)
     end
+
+    #
+    # Compare two struct fields for equality
+    #
+    def sk_comparison_for(field_name, field_data, is_last)
+      if field_data[:is_array]
+        sk_array_comparison_for(field_name, field_data, is_last)
+      else
+        ["lhs.#{field_name} == rhs.#{field_name}#{is_last ? ';' : ' &&'}"]
+      end
+    end
+
+    #
+    # Compare two array fields for equality
+    #
+    def sk_array_comparison_for(field_name, field_data, is_last)
+      array_size = field_data[:array_dimension_sizes].inject(:*)
+      result = (0...array_size).map do |i|
+        is_last_element = is_last && (i == array_size - 1)
+        "lhs.#{field_name}[#{i}] == rhs.#{field_name}[#{i}]#{is_last_element ? '' : ' &&'}"
+      end
+      result[-1] += ';' if is_last
+      result
+    end
   end
 end


### PR DESCRIPTION
# Description
Added generation of equality (==) and inequality (!=) operators to the ERB templates for cpp SplashKit types. This ensures consistent functionality across ffi bindings and reduces manual coding effort.

This allows you to check equality of these structs. for example color_black() == color_black()

# Changes
- Updated the ERB template to generate:
    - inline operator== comparing all fields of structs
    - inline operator!= implemented in terms of the equality operator

# Example Generated Code
```cpp
inline bool operator==(const point_2d& lhs, const point_2d& rhs) {
    return 
        lhs.x == rhs.x && 
        lhs.y == rhs.y; 
}

inline bool operator!=(const point_2d& lhs, const point_2d& rhs) {
    return !(lhs == rhs);
}
```
# Example Usage
```cpp
point_2d p1 = {1.0, 2.0};
point_2d p2 = {1.0, 2.0};
if (p1 == p2)
```

Testing
- [x] Verified generation works for all struct types
- [x] Confirmed proper formatting and indentation
- [x] Tested generated operators function correctly

