### PR TITLE
Bugfix/pascal ffi generation issues

### DIFF
--- a/res/translators/pascal/implementation/mappers/string.pas.erb
+++ b/res/translators/pascal/implementation/mappers/string.pas.erb
@@ -15,6 +15,7 @@ begin
 end;
 function __skadapter__to_string(s: __sklib_string): String;
 begin
-  result := String(s.str);
+  SetLength(result, strlen(s.str));
+  Move(s.str^, result[1], strlen(s.str));
   __sklib__free__sklib_string(s);
 end;

--- a/res/translators/pascal/implementation/mappers/string.pas.erb
+++ b/res/translators/pascal/implementation/mappers/string.pas.erb
@@ -15,7 +15,7 @@ begin
 end;
 function __skadapter__to_string(s: __sklib_string): String;
 begin
-  SetLength(result, strlen(s.str));
-  Move(s.str^, result[1], strlen(s.str));
+  SetLength(result, s.size);
+  Move(s.str^, result[1], s.size);
   __sklib__free__sklib_string(s);
 end;

--- a/res/translators/pascal/implementation/mappers/string.pas.erb
+++ b/res/translators/pascal/implementation/mappers/string.pas.erb
@@ -15,6 +15,6 @@ begin
 end;
 function __skadapter__to_string(s: __sklib_string): String;
 begin
-  result := StrPas(s.str);
+  result := String(s.str);
   __sklib__free__sklib_string(s);
 end;

--- a/res/translators/pascal/implementation/mappers/vector.pas.erb
+++ b/res/translators/pascal/implementation/mappers/vector.pas.erb
@@ -52,6 +52,7 @@ function __skadapter__to_sklib_vector_<%= type %>(const v: ArrayOf<%= sk_type %>
 var
     i: Integer;
 begin
+  result := nil;
   result.size_from_lib := 0;
   result.data_from_lib := nil;
   result.size_from_app := Length(v);
@@ -69,6 +70,7 @@ function __skadapter__to_vector_<%= type %>(const v: __sklib_vector_<%= type %>)
 var
   i: Integer;
 begin
+  result := nil;
   SetLength(result, v.size_from_lib);
   for i := 0 to v.size_from_lib - 1 do
   begin
@@ -90,6 +92,7 @@ procedure __skadapter__update_from_vector_<%= type %>(var v: __sklib_vector_<%= 
 var
   i: Integer;
 begin
+  __skreturn := nil;
   SetLength(__skreturn, v.size_from_lib);
   for i := 0 to v.size_from_lib - 1 do
   begin

--- a/res/translators/pascal/implementation/mappers/vector.pas.erb
+++ b/res/translators/pascal/implementation/mappers/vector.pas.erb
@@ -52,7 +52,6 @@ function __skadapter__to_sklib_vector_<%= type %>(const v: ArrayOf<%= sk_type %>
 var
     i: Integer;
 begin
-  result := nil;
   result.size_from_lib := 0;
   result.data_from_lib := nil;
   result.size_from_app := Length(v);

--- a/res/translators/pascal/interface/types/enum.pas.erb
+++ b/res/translators/pascal/interface/types/enum.pas.erb
@@ -6,8 +6,13 @@
 %>
 type <%= enum[:name].type_case %> = (
 <%
-    enum[:constants].each do |constant_key, constant_data|
-      is_last = constant_key == enum[:constants].keys.last
+    # Sort constants by their numeric value
+    sorted_constants = enum[:constants].sort_by do |_, constant_data|
+      constant_data[:number].is_a?(Integer) ? constant_data[:number] : -1
+    end
+    
+    sorted_constants.each_with_index do |(constant_key, constant_data), index|
+      is_last = index == sorted_constants.length - 1
       has_numb = constant_data[:number].is_a? Integer
       numb = " = #{constant_data[:number]}" if has_numb
       last = ',' unless is_last
@@ -16,7 +21,7 @@ type <%= enum[:name].type_case %> = (
   <%= constant_decl %>
 
 <%
-    end # end enums.each
+    end # end sorted_constants.each
 %>
 );
 <%

--- a/res/translators/pascal/interface/types/enum.pas.erb
+++ b/res/translators/pascal/interface/types/enum.pas.erb
@@ -7,12 +7,22 @@
 type <%= enum[:name].type_case %> = (
 <%
     # Sort constants by their numeric value
+    seen_numbers = {}
     sorted_constants = enum[:constants].sort_by do |_, constant_data|
       constant_data[:number].is_a?(Integer) ? constant_data[:number] : -1
     end
     
-    sorted_constants.each_with_index do |(constant_key, constant_data), index|
-      is_last = index == sorted_constants.length - 1
+    # Filter out duplicates and track valid entries
+    valid_constants = []
+    sorted_constants.each do |constant_key, constant_data|
+      has_numb = constant_data[:number].is_a? Integer
+      next if has_numb && seen_numbers[constant_data[:number]]
+      seen_numbers[constant_data[:number]] = true if has_numb
+      valid_constants << [constant_key, constant_data]
+    end
+
+    valid_constants.each_with_index do |(constant_key, constant_data), index|
+      is_last = index == valid_constants.length - 1
       has_numb = constant_data[:number].is_a? Integer
       numb = " = #{constant_data[:number]}" if has_numb
       last = ',' unless is_last
@@ -21,7 +31,7 @@ type <%= enum[:name].type_case %> = (
   <%= constant_decl %>
 
 <%
-    end # end sorted_constants.each
+    end # end valid_constants.each
 %>
 );
 <%


### PR DESCRIPTION
## Description

This pull request addresses several issues in the pascal translation:

1. **StrPas Issue**: 
   - **Problem**: The `StrPas` function was causing inlining warnings during string concatenation operations.
   - **Fix**: Replaced StrPas(s.str) with direct memory management. (works for fpc and pascal)

2. **Uninitialized Result**:
   - **Problem**: All of the vector conversions were throwing errors due to the result being uninitialized. 
   - **Fix**: Initialized `result` to `nil`.

3. **Enum Value Order Issue**:
   - **Problem**: Enums were showing an error because the enum values were not in descending order and they had default values which arent supported. 
   - **Fix**: Sorted enum constants by their numeric value in descending order and skipped duplicate defaults (still works since c handles defaults).


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Verified that the string conversion issue is resolved.
- Verified that uninitialized result variables no longer throw errors.
- Checked that enums now compile without errors and constants appear in descending order.

## Testing Checklist

- [x] Verified fixes through test generator.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.