### PR TITLE
Bugfix/python ffi fixes

### DIFF
--- a/res/translators/python/ctypes/mappers/bool.py.erb
+++ b/res/translators/python/ctypes/mappers/bool.py.erb
@@ -13,4 +13,4 @@ def __skadapter__to_sklib_bool(v):
 def __skadapter__to_bool(v):
     if isinstance(v, c_bool):
         return v
-    return v != 0;
+    return v != 0

--- a/res/translators/python/ctypes/mappers/bool.py.erb
+++ b/res/translators/python/ctypes/mappers/bool.py.erb
@@ -4,7 +4,7 @@
 def __skadapter__to_sklib_bool(v):
     if isinstance(v, c_int32):  
         return v
-    return 1 if v else 0
+    return c_int32(1) if v else c_int32(0)
 
 def __skadapter__to_bool(v):
     if isinstance(v, bool):

--- a/res/translators/python/ctypes/mappers/bool.py.erb
+++ b/res/translators/python/ctypes/mappers/bool.py.erb
@@ -2,15 +2,11 @@
   Mappers from `Boolean` <-> `LongInt`
 %>
 def __skadapter__to_sklib_bool(v):
-    if isinstance(v, c_bool):
+    if isinstance(v, c_int32):  
         return v
-
-    if v:
-        return -1
-    else:
-        return 0
+    return 1 if v else 0
 
 def __skadapter__to_bool(v):
-    if isinstance(v, c_bool):
+    if isinstance(v, bool):
         return v
-    return v != 0
+    return bool(v)  

--- a/res/translators/python/ctypes/mappers/char.py.erb
+++ b/res/translators/python/ctypes/mappers/char.py.erb
@@ -3,7 +3,7 @@ def __skadapter__to_sklib_char(v):
         return c_char(str.encode(v)[0])
     if isinstance(v, c_char):
         return v
-    return c_char(v);
+    return c_char(v)
 
 def __skadapter__to_char(v):
     if isinstance(v, bytes):
@@ -15,7 +15,7 @@ def __skadapter__to_sklib_unsigned_char(v):
         return v
     if isinstance(v, str):
         return c_ubyte(ord(v[0]))
-    return c_ubyte(ord(v));
+    return c_ubyte(ord(v))
 
 def __skadapter__to_unsigned_char(v):
     if isinstance(v, c_ubyte):

--- a/res/translators/python/ctypes/mappers/direct.py.erb
+++ b/res/translators/python/ctypes/mappers/direct.py.erb
@@ -10,7 +10,7 @@
 def __skadapter__to_sklib_<%= c_type %>(v):
     if isinstance(v, <%= py_ctype %>):
         return v
-    return <%= py_ctype %>(v);
+    return <%= py_ctype %>(v)
 
 def __skadapter__to_<%= c_type %>(v):
     return v

--- a/res/translators/python/ctypes/mappers/struct.py.erb
+++ b/res/translators/python/ctypes/mappers/struct.py.erb
@@ -53,7 +53,7 @@ def __skadapter__to_<%= struct[:name] %>(v):
       if field_data[:is_array]
         array_size_as_one_dimensional(field_data).times do |i|
 %>
-    result.<%= field_name %><%= array_mapper_index_for(field_data, i) %> = <%= sk_mapper_fn_for field_data %>(v.<%= field_name %>[<%= i %>]);
+    result.<%= field_name %><%= array_mapper_index_for(field_data, i) %> = <%= sk_mapper_fn_for field_data %>(v.<%= field_name %>[<%= i %>])
 <%
         end # end times
       else # else standard copy converted as SK type using SK type mapper

--- a/res/translators/python/ctypes/mappers/typealias_pointer.py.erb
+++ b/res/translators/python/ctypes/mappers/typealias_pointer.py.erb
@@ -30,9 +30,21 @@ def __skadapter__to_ptr(v):
 def __skadapter__to_<%= typealias %>(v):
     return _find_pointer_resource(v, "<%= typealias.type_case %>")
 
+<%
+    if typealias == "json"
+%>
+def __skadapter__to_sklib_<%= typealias %>(v):
+    if isinstance(v, c_void_p):
+        return v
+    return cast(v, c_void_p)
+
+<%
+    else
+%>
 def __skadapter__to_sklib_<%= typealias %>(v):
     return v
 
 <%
+    end
   end # typealiases.each
 %>

--- a/res/translators/python/ctypes/types/struct.py.erb
+++ b/res/translators/python/ctypes/types/struct.py.erb
@@ -39,7 +39,7 @@ class <%= sklib_prefix() %>_<%= struct[:name].variable_case %>(Structure):
     ]
 
     def __init__(self):
-      super().__init__()
+        super().__init__()
 
 <%
     struct[:fields].each do |field_name, field_data|
@@ -76,7 +76,10 @@ class <%= sklib_prefix() %>_<%= struct[:name].variable_case %>(Structure):
 %>
     @property
     def <%= field_name %>(self):
-        return  _FieldIndexer(self, "_<%= field_name %>", <%=dim1%>, <%=dim2%>)
+        indexer_name = "_<%= field_name %>_indexer"
+        if not hasattr(self, indexer_name):
+            setattr(self, indexer_name, _FieldIndexer(self, "_<%= field_name %>", <%=dim1%>, <%=dim2%>))
+        return getattr(self, indexer_name)
 <%
       end # if
     end # fields each

--- a/res/translators/python/ctypes/types/struct.py.erb
+++ b/res/translators/python/ctypes/types/struct.py.erb
@@ -30,9 +30,7 @@ class <%= sklib_prefix() %>_<%= struct[:name].variable_case %>(Structure):
 <%
     # Convert each field type into Python type
     struct[:fields].each do |field_name, field_data|
-      if field_data[:is_array] || enum_type = @enums.select { |e| e[:name] == field_data[:type]}.first
-        field_name = "_#{field_name}"
-      end
+      field_name = field_name_for(field_name, field_data)
 %>
         ("<%= field_name.variable_case %>", <%= lib_type_for(field_data) %>),
 <%
@@ -41,20 +39,6 @@ class <%= sklib_prefix() %>_<%= struct[:name].variable_case %>(Structure):
     ]
 
     def __init__(self):
-<%
-    struct[:fields].each do |field_name, field_data|
-      # Ensure field name is in correct case for language
-      field_name = field_name.variable_case
-      # If an array copy over each value in the array (1D array << {1,2}D array)
-      if field_data[:is_array]
-        dim1 = field_data[:array_dimension_sizes][0]
-        dim2 = field_data[:array_dimension_sizes][1] || 0
-%>
-      self.<%= field_name %> = _FieldIndexer(self, "_<%= field_name %>", <%=dim1%>, <%=dim2%>)
-<%
-      end # end if
-    end # end fields.each
-%>
       super().__init__()
 
 <%
@@ -82,6 +66,22 @@ class <%= sklib_prefix() %>_<%= struct[:name].variable_case %>(Structure):
       end # if
     end # fields each
 %>
+<% struct[:fields].each do |field_name, field_data| %>
+<%
+      # If an array, return a list/2d list representation of the array
+      field_name = field_name.variable_case
+      if field_data[:is_array]
+        dim1 = field_data[:array_dimension_sizes][0]
+        dim2 = field_data[:array_dimension_sizes][1] || 0
+%>
+    @property
+    def <%= field_name %>(self):
+        return  _FieldIndexer(self, "_<%= field_name %>", <%=dim1%>, <%=dim2%>)
+<%
+      end # if
+    end # fields each
+%>
+
 <%= struct[:name].type_case %> = <%= sklib_prefix() %>_<%= struct[:name].variable_case %>
 
 <%

--- a/src/translators/python.rb
+++ b/src/translators/python.rb
@@ -46,7 +46,7 @@ module Translators
     }
     SK_TYPES_TO_LIB_TYPES = {
       'string'    => '_sklib_string',
-      'bool'      => 'c_bool',
+      'bool'      => 'c_int32',
       'char'      => 'c_char',
       'enum'      => 'c_int',
       'unsigned char'   => 'c_ubyte',


### PR DESCRIPTION
## Description

This pull request addresses multiple initialization and type conversion issues:

1. **Matrix/Array Field Access Issue**: 
   - **Problem**: Objects created through FFI bypass Python's `__init__`, making the initialization of field indexers fail. This happens because the adapter functions (`__skadapter__to_sklib_matrix_2d` and similar) just return the FFI instance directly without creating a new object.
   - **Fix**: Implemented lazy initialization through properties instead of relying on `__init__`.
   
2. **Semi colons in erb python files**
   - **Problem**: Some python erb mappings had semi colons in them. 
   - **Fix**: This wasnt generating errors as they're optional but i removed them regardless to keep it consistant.

3. **JSON Vector Array Assignment Bypassing as_parameter Conversion**
   - **Problem**: When assigning JSON wrapper objects to vector array elements, ctypes bypasses the automatic `_as_parameter_` conversion that normally handles C pointer conversion. This occurs in:
   
        ```python
        def __skadapter__to_sklib_vector_json(v):
            result = _sklib_vector_json(len(v))
            for i in range(0, len(v)):
                result.data_from_app[i] = __skadapter__to_sklib_json(v[i])
            return result
        ```
   - **Fix**: Add explicit casting in `__skadapter__to_sklib_json` to handle array assignment case:
 
4. **Boolean Type Conversion**
   - **Problem**: Boolean values were being incorrectly converted using c_bool (1 byte) instead of c_int32 (4 bytes). SplashKit internally uses 4-byte integers to represent booleans, so using c_bool caused incorrect value reading when accessing boolean arrays in JSON.
   - **Fix**: Updated to use c_int32 to match SplashKit's native boolean representation.

Before:   
```python
# Array properties
class _sklib_matrix_2d(Structure):
_fields_ = [
    ("_elements", c_double * 9),
]

def __init__(self):
    self.elements = _FieldIndexer(self, "_elements", 3, 3)
    super().__init__()

# Json conversion
def __skadapter__to_sklib_json(v):
    return v
```
After:
```python
# Array properties
class _sklib_matrix_2d(Structure):
    _fields_ = [
        ("_elements", c_double * 9),
    ]

    def __init__(self):
        super().__init__()
    
@property
  def elements(self):
      indexer_name = "_elements_indexer"
      if not hasattr(self, indexer_name):
          setattr(self, indexer_name, _FieldIndexer(self, "_elements", 3, 3))
      return getattr(self, indexer_name)

# Json conversion
def __skadapter__to_sklib_json(v):
    if isinstance(v, c_void_p):
        return v
    return cast(v, c_void_p)
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Confirmed that array access in structures functions properly
- Tested matrix operations
- Confirmed that converting json arrays no longger generates an error
- Confirmed boolean conversion now works

## Testing Checklist

- [x] Verified fixes through test generator.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.